### PR TITLE
fix cronjob sync escaping issue with env vars

### DIFF
--- a/src/Deployer/Task/PlatformConfiguration/CronSyncTask.php
+++ b/src/Deployer/Task/PlatformConfiguration/CronSyncTask.php
@@ -35,7 +35,7 @@ class CronSyncTask extends TaskBase implements ConfigurableTaskInterface
 
     public function setCrontab(string $newCrontab): void
     {
-        run('echo "' . $newCrontab . '" | crontab -');
+        run("echo $'" . str_replace('\'', '\\\'', $newCrontab) . "' | crontab -");
     }
 
     public function replaceExistingCronBlocks(string $newCronBlock): string


### PR DESCRIPTION
Environment variables were disappearing after crontab is synced.
Should be fixed now by properly escaping.

Assuming cron job which gets deployed.

```
MAGENTO_DOCROOT=/data/web/apps/mydomain.com/current
MAGENTO_PHPBIN=php

0 4 * * * cd $MAGENTO_DOCROOT && $MAGENTO_PHPBIN ./bin/magento foo-bar
```

After deployment on the server crontab is as follows:

```
MAGENTO_DOCROOT=/data/web/apps/mydomain.com/current
MAGENTO_PHPBIN=php

0 4 * * * cd && ./bin/magento foo-bar
```

This PR fixes the issue.